### PR TITLE
Fix relative link in up-and-running.rst

### DIFF
--- a/versions/v10.0.0/guides/up-and-running.rst
+++ b/versions/v10.0.0/guides/up-and-running.rst
@@ -6,7 +6,7 @@ Up and Running
 
 The aim of this first guide is to get an Exponent application up and running as quickly as possible.
 
-At this point we should have XDE installed on our development machine and the Exponent client on an iOS or Android physical device or emulator. If not, go back to the `Installation </introduction/installation.html>`_ guide before proceeding.
+At this point we should have XDE installed on our development machine and the Exponent client on an iOS or Android physical device or emulator. If not, go back to the `Installation <../introduction/installation.html>`_ guide before proceeding.
 
 Alright, let's get started.
 


### PR DESCRIPTION
The installation instruction link currently leads to 404
This change makes it relative to the file

Note: first time using rst for the documentation, I may have a wrong idea about how the hyperlinks work here.