### PR TITLE
Update documentation to match module functionality

### DIFF
--- a/versions/v10.0.0/sdk/video.rst
+++ b/versions/v10.0.0/sdk/video.rst
@@ -14,7 +14,7 @@ Video
 
       The source of the video data to display. The following forms are supported:
 
-      - A string with a network URL pointing to a video file on the web.
+      - A hash of the format ``{ uri: my_url }`` where ``my_url`` is a string with a network URL pointing to a video file on the web.
       - ``require('path/to/file')`` for a video file asset in the source code
         directory.
 


### PR DESCRIPTION
I just spend 20 minutes trying to work out why the app was failing on my device when I was following the docs only to realise the docs didn't match the module: https://github.com/exponentjs/exponent-sdk/blob/6a07b8be5a3ab1eb9ca048284ae0520d7649e4e6/src/Components/Video.js#L144