### PR TITLE
Double click on Exp icon doesn't open debugging menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ actually an SDK version, it's just a special version that corresponds to the
 Some times you want to make an edit in version `X` but then have that edit also
 be applied in versions `Y, Z, ...` (say when you're fixing documentation for an
 API call that existed in old versions too). You can use the
-`./scripts/versionpatch.sh` utiltiy to apply your `git diff` in one version in
+`./scripts/versionpatch.sh` utility to apply your `git diff` in one version in
 other versions. For example, to update the docs in `unversioned` then apply it
 on `v8.0.0` and `v7.0.0`, you'd do the following after editing the docs in
 `unversioned` such that it shows up in `git diff`:

--- a/versions/unversioned/guides/debugging.rst
+++ b/versions/unversioned/guides/debugging.rst
@@ -47,7 +47,7 @@ execute code, etc, as you would when debugging a web app.
   as your development machine. This may not work on some public networks.
   ``localhost`` will not work for iOS unless you are in the simulator, and it
   only work on Android if your device is connected to your machine via usb.
-- Open the app on your device, then shake the device a little bit to reveal the
+- Open the app on your device, then shake the device a little bit (or hit `Ctrl-Cmd-Z` on a Mac in the emulator) to reveal the
   developer menu. Tap on ``Debug JS Remotely``. This should open up a Chrome
   tab with the URL ``http://localhost:19001/debugger-ui``. From there, you can
   set breakpoints and interact through the JavaScript console. Shake the
@@ -99,7 +99,7 @@ Hot Reloading and Live Reloading
 ================================
 `Hot Module Reloading <http://facebook.github.io/react-native/blog/2016/03/24/introducing-hot-reloading.html>`_
 is a quick way to reload changes without losing your state in the screen or
-navigation stack. To enable, just shake your device and tap the "Enable Hot
+navigation stack. To enable, just shake your device (or hit `Ctrl-Cmd-Z` on a Mac in the emulator) and tap the "Enable Hot
 Reloading" item. Whereas Live Reload will reload the entire JS context, Hot
 Module Reloading will make your debug cycles even faster. However, make sure
 you don't have both options turned on, as that is unsupported behavior.

--- a/versions/v10.0.0/guides/debugging.rst.orig
+++ b/versions/v10.0.0/guides/debugging.rst.orig
@@ -53,7 +53,7 @@ execute code, etc, as you would when debugging a web app.
   as your development machine. This may not work on some public networks.
   ``localhost`` will not work for iOS unless you are in the simulator, and it
   only work on Android if your device is connected to your machine via usb.
-- Open the app on your device, then shake the device a little bit (or hit `Ctrl-Cmd-Z` on a Mac in the emulator) to reveal the
+- Open the app on your device, then shake the device a little bit to reveal the
   developer menu. Tap on ``Debug JS Remotely``. This should open up a Chrome
   tab with the URL ``http://localhost:19001/debugger-ui``. From there, you can
   set breakpoints and interact through the JavaScript console. Shake the
@@ -105,7 +105,7 @@ Hot Reloading and Live Reloading
 ================================
 `Hot Module Reloading <http://facebook.github.io/react-native/blog/2016/03/24/introducing-hot-reloading.html>`_
 is a quick way to reload changes without losing your state in the screen or
-navigation stack. To enable, just shake your device (or hit `Ctrl-Cmd-Z` on a Mac in the emulator) and tap the "Enable Hot
+navigation stack. To enable, just shake your device and tap the "Enable Hot
 Reloading" item. Whereas Live Reload will reload the entire JS context, Hot
 Module Reloading will make your debug cycles even faster. However, make sure
 you don't have both options turned on, as that is unsupported behavior.


### PR DESCRIPTION
* But Ctrl-Cmd-Z does in the E(/Si)mulator.